### PR TITLE
회원 탈퇴 추가 및 구독 수정

### DIFF
--- a/src/main/java/com/triplea/triplea/controller/UserController.java
+++ b/src/main/java/com/triplea/triplea/controller/UserController.java
@@ -83,8 +83,8 @@ public class UserController {
 
     // 구독
     @GetMapping("/subscribe")
-    public ResponseEntity<?> subscribe(@AuthenticationPrincipal MyUserDetails myUserDetails) {
-        UserResponse.Payment payment = userService.subscribe(myUserDetails.getUser());
+    public ResponseEntity<?> subscribe(@RequestParam("dev") Boolean dev, @AuthenticationPrincipal MyUserDetails myUserDetails) {
+        UserResponse.Payment payment = userService.subscribe(dev, myUserDetails.getUser());
         return ResponseEntity.ok().body(new ResponseDTO<>(payment));
     }
 

--- a/src/main/java/com/triplea/triplea/controller/UserController.java
+++ b/src/main/java/com/triplea/triplea/controller/UserController.java
@@ -9,8 +9,6 @@ import com.triplea.triplea.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
-import com.triplea.triplea.service.UserService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.Errors;
@@ -109,5 +107,12 @@ public class UserController {
     public ResponseEntity<?> subscribeSession(@AuthenticationPrincipal MyUserDetails myUserDetails) {
         UserResponse.Session session = userService.subscribeSession(myUserDetails.getUser());
         return ResponseEntity.ok().body(new ResponseDTO<>(session));
+    }
+
+    // 회원탈퇴
+    @DeleteMapping("/user")
+    public ResponseEntity<?> deactivateAccount(@AuthenticationPrincipal MyUserDetails myUserDetails){
+        userService.deactivateAccount(myUserDetails.getUser());
+        return ResponseEntity.ok().body(new ResponseDTO<>());
     }
 }

--- a/src/main/java/com/triplea/triplea/core/util/StepPaySubscriber.java
+++ b/src/main/java/com/triplea/triplea/core/util/StepPaySubscriber.java
@@ -108,8 +108,9 @@ public class StepPaySubscriber {
      * @return Response
      * @throws IOException execute
      */
-    public Response getPaymentLink(String orderCode) throws IOException {
-        String successUrl = "";
+    public Response getPaymentLink(boolean dev, String orderCode) throws IOException {
+        String successUrl = "54.180.102.131/payment";
+        if(dev) successUrl = "localhost:3000/payment";
         Request request = new Request.Builder()
                 .url("https://api.steppay.kr/api/v1/orders/" + orderCode + "/pay?successUrl=" + successUrl)
                 .get()

--- a/src/main/java/com/triplea/triplea/service/UserService.java
+++ b/src/main/java/com/triplea/triplea/service/UserService.java
@@ -144,11 +144,12 @@ public class UserService {
 
     // 구독
     public UserResponse.Payment subscribe(User user) {
+        User loginUser = getUser(user);
         String orderCode;
         // 이미 구독을 한 적 있으면 새로 고객 생성을 하지 않기 위해
         UserRequest.Order order = customerRepository.findCustomerByUserId(user.getId())
                 .map(this::createOrderWithExistingCustomer)
-                .orElseGet(() -> createOrderWithNewCustomer(user));
+                .orElseGet(() -> createOrderWithNewCustomer(loginUser));
         // 주문 생성
         try (Response getOrder = subscriber.postOrder(order)) {
             orderCode = subscriber.getOrderCode(getOrder);
@@ -169,6 +170,7 @@ public class UserService {
     // 구독 확인
     @Transactional
     public void subscribeOk(String orderCode, User user) {
+        user = getUser(user);
         Customer customer = getCustomer(user);
         try (Response response = subscriber.getOrder(orderCode)) {
             if (response.isSuccessful()) {
@@ -186,16 +188,13 @@ public class UserService {
     // 구독 취소
     @Transactional
     public void subscribeCancel(User user) {
-        Customer customer = getCustomer(user);
-        try (Response response = subscriber.cancelSubscription(customer.getSubscriptionId())) {
-            if (response.isSuccessful()) customer.deactivateSubscription();
-        } catch (Exception e) {
-            throw new Exception500("구독 취소 실패: " + e.getMessage());
-        }
+        user = getUser(user);
+        cancelSubscriptionIfSubscribed(user);
     }
 
     // 구독내역 조회용 세션키
     public UserResponse.Session subscribeSession(User user) {
+        user = getUser(user);
         Customer customer = getCustomer(user);
         Long customerId = customer.getId();
         try (Response response = subscriber.getSession(customerId)) {
@@ -209,6 +208,40 @@ public class UserService {
             throw new Exception500("Step Pay 세션 생성회 API 실패");
         } catch (Exception e) {
             throw new Exception500("세션 생성 실패: " + e.getMessage());
+        }
+    }
+
+    // 회원탈퇴
+    @Transactional
+    public void deactivateAccount(User user) {
+        user = getUser(user);
+        cancelSubscriptionIfSubscribed(user);
+        user.deactivateAccount();
+    }
+
+    private User getUser(User user) {
+        return userRepository.findById(user.getId()).orElseThrow(
+                () -> new Exception401("잘못된 접근입니다"));
+    }
+
+    private void cancelSubscriptionIfSubscribed(User user) {
+        if (User.Membership.BASIC == user.getMembership()) return;
+
+        Customer customer = getCustomer(user);
+        try {
+            if (subscriber.isSubscribe(customer.getSubscriptionId())) {
+                cancelSubscription(customer);
+            } else customer.deactivateSubscription();
+        } catch (Exception e) {
+            throw new Exception500("구독 확인 실패: " + e.getMessage());
+        }
+    }
+
+    private void cancelSubscription(Customer customer) {
+        try (Response response = subscriber.cancelSubscription(customer.getSubscriptionId())) {
+            if (response.isSuccessful()) customer.deactivateSubscription();
+        } catch (Exception e) {
+            throw new Exception500("구독 취소 실패: " + e.getMessage());
         }
     }
 
@@ -229,12 +262,12 @@ public class UserService {
     /**
      * 구독한 적이 없다면 step pay 고객 생성 API로 고객 등록 후 주문 생성
      */
-    private UserRequest.Order createOrderWithNewCustomer(User user) throws Exception500 {
+    private UserRequest.Order createOrderWithNewCustomer(User user) {
         try (Response postCustomer = subscriber.postCustomer(user)) {
             UserRequest.Order order = subscriber.responseCustomer(postCustomer, productCode, priceCode);
             createCustomer(order, user);
             return order;
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new Exception500("고객 생성 실패: " + e.getMessage());
         }
     }

--- a/src/main/java/com/triplea/triplea/service/UserService.java
+++ b/src/main/java/com/triplea/triplea/service/UserService.java
@@ -143,7 +143,7 @@ public class UserService {
     }
 
     // 구독
-    public UserResponse.Payment subscribe(User user) {
+    public UserResponse.Payment subscribe(Boolean dev, User user) {
         User loginUser = getUser(user);
         String orderCode;
         // 이미 구독을 한 적 있으면 새로 고객 생성을 하지 않기 위해
@@ -157,7 +157,7 @@ public class UserService {
             throw new Exception500("주문 생성 실패: " + e.getMessage());
         }
         // 결제 링크
-        try (Response getLink = subscriber.getPaymentLink(orderCode)) {
+        try (Response getLink = subscriber.getPaymentLink(dev, orderCode)) {
             if (getLink.isSuccessful()) {
                 return new UserResponse.Payment(getLink.request().url().url());
             }
@@ -189,7 +189,9 @@ public class UserService {
     @Transactional
     public void subscribeCancel(User user) {
         user = getUser(user);
-        cancelSubscriptionIfSubscribed(user);
+        if(user.getMembership() != User.Membership.PREMIUM) throw new Exception400("subscribe", "구독 중이 아닙니다");
+        Customer customer = getCustomer(user);
+        cancelSubscription(customer);
     }
 
     // 구독내역 조회용 세션키

--- a/src/test/java/com/triplea/triplea/controller/UserControllerTest.java
+++ b/src/test/java/com/triplea/triplea/controller/UserControllerTest.java
@@ -147,9 +147,9 @@ class UserControllerTest {
         String accessToken = MyJwtProvider.createAccessToken(user);
         //when
         String url = "https://example.com";
-        when(userService.subscribe(any(User.class))).thenReturn(new UserResponse.Payment(new URL(url)));
+        when(userService.subscribe(anyBoolean(), any(User.class))).thenReturn(new UserResponse.Payment(new URL(url)));
         //then
-        mockMvc.perform(get("/api/subscribe")
+        mockMvc.perform(get("/api/subscribe?dev=true")
                         .with(csrf())
                         .header(MyJwtProvider.HEADER, accessToken))
                 .andExpect(MockMvcResultMatchers.status().isOk())

--- a/src/test/java/com/triplea/triplea/controller/UserControllerTest.java
+++ b/src/test/java/com/triplea/triplea/controller/UserControllerTest.java
@@ -11,12 +11,6 @@ import com.triplea.triplea.model.user.User;
 import com.triplea.triplea.service.RedisService;
 import com.triplea.triplea.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
-import com.triplea.triplea.core.auth.jwt.MyJwtProvider;
-import com.triplea.triplea.core.config.MySecurityConfig;
-import com.triplea.triplea.dto.user.UserRequest;
-import com.triplea.triplea.dto.user.UserResponse;
-import com.triplea.triplea.model.user.User;
-import com.triplea.triplea.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -226,5 +220,19 @@ class UserControllerTest {
         //then
         verify(userService).login(any(), any(), any());
 
+    }
+
+    @Test
+    @DisplayName("회원탈퇴")
+    void deactivateAccount() throws Exception {
+        //given
+        String accessToken = MyJwtProvider.createAccessToken(user);
+        //when
+        //then
+        mockMvc.perform(delete("/api/user")
+                        .with(csrf())
+                        .header(MyJwtProvider.HEADER, accessToken))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
     }
 }


### PR DESCRIPTION
## Motivation

- 회원탈퇴(soft delete)로 비활성 계정으로 전환(구독한 경우 구독 취소 진행) 및 구독 API, test code 수정
- close #14 #68 

## Proposed Changes

- 결제 성공 redirect url 추가
- test code 수정 및 추가
- 구독 API user 검증 추가

## To reviewers

- 주의할 점
- 안내사항