### PR TITLE
queryDSL로 변경(History, BookmarkNews)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,12 +51,28 @@ dependencies {
     // swagger
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
 
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0'
+    annotationProcessor(
+            "javax.persistence:javax.persistence-api",
+            "javax.annotation:javax.annotation-api",
+            "com.querydsl:querydsl-apt:5.0.0:jpa")
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+}
+
+// QueryDSL
+sourceSets{
+    main{
+        java{
+            srcDirs = ["$projectDir/src/main/java", "$projectDir/build/generated"]
+        }
+    }
 }
 
 ext {

--- a/src/main/java/com/triplea/triplea/model/bookmark/BookmarkCategory.java
+++ b/src/main/java/com/triplea/triplea/model/bookmark/BookmarkCategory.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @Table(name = "bookmark_category_tb")
 public class BookmarkCategory {
-    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/triplea/triplea/model/bookmark/BookmarkNews.java
+++ b/src/main/java/com/triplea/triplea/model/bookmark/BookmarkNews.java
@@ -1,19 +1,18 @@
 package com.triplea.triplea.model.bookmark;
 
+import com.querydsl.core.annotations.QueryEntity;
 import com.triplea.triplea.core.util.timestamp.CreatedTimestamped;
 import com.triplea.triplea.model.user.User;
 import lombok.*;
 
 import javax.persistence.*;
 
-@Builder
-@Setter
+@Setter @QueryEntity
 @Getter @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Table(name = "bookmark_news_tb")
 public class BookmarkNews extends CreatedTimestamped {
-    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -26,6 +25,13 @@ public class BookmarkNews extends CreatedTimestamped {
     @Column(nullable = false)
     private boolean isDeleted;
 
+    @Builder
+    public BookmarkNews(Long id, User user, Long newsId, boolean isDeleted) {
+        this.id = id;
+        this.user = user;
+        this.newsId = newsId;
+        this.isDeleted = isDeleted;
+    }
 
     public BookmarkNews(User user, Long newsId) {
         this.user = user;

--- a/src/main/java/com/triplea/triplea/model/bookmark/BookmarkNewsQuerydslRepository.java
+++ b/src/main/java/com/triplea/triplea/model/bookmark/BookmarkNewsQuerydslRepository.java
@@ -1,0 +1,8 @@
+package com.triplea.triplea.model.bookmark;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface BookmarkNewsQuerydslRepository {
+    List<BookmarkNews> findByCreatedAtAndUser(LocalDate date, Long userId);
+}

--- a/src/main/java/com/triplea/triplea/model/bookmark/BookmarkNewsQuerydslRepositoryImpl.java
+++ b/src/main/java/com/triplea/triplea/model/bookmark/BookmarkNewsQuerydslRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.triplea.triplea.model.bookmark;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.triplea.triplea.core.util.timestamp.Timestamped;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Repository
+public class BookmarkNewsQuerydslRepositoryImpl implements BookmarkNewsQuerydslRepository{
+    private final JPAQueryFactory queryFactory;
+    private final QBookmarkNews bookmarkNews = QBookmarkNews.bookmarkNews;
+
+    public BookmarkNewsQuerydslRepositoryImpl(EntityManager entityManager) {
+        this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+    @Override
+    public List<BookmarkNews> findByCreatedAtAndUser(LocalDate date, Long userId) {
+        ZonedDateTime startDateTime = ZonedDateTime.of(date, LocalTime.MIN, Timestamped.SEOUL_ZONE_ID);
+        ZonedDateTime endDateTime = ZonedDateTime.of(date, LocalTime.MAX, Timestamped.SEOUL_ZONE_ID);
+
+        return queryFactory.selectFrom(bookmarkNews)
+                .where(bookmarkNews.createdAt.between(startDateTime, endDateTime)
+                        .and(bookmarkNews.user.id.eq(userId)))
+                .fetch();
+    }
+}

--- a/src/main/java/com/triplea/triplea/model/bookmark/BookmarkNewsRepository.java
+++ b/src/main/java/com/triplea/triplea/model/bookmark/BookmarkNewsRepository.java
@@ -4,7 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,7 +18,7 @@ public interface BookmarkNewsRepository extends JpaRepository<BookmarkNews, Long
     @Query("select count(bn) from BookmarkNews bn where bn.isDeleted=false and bn.newsId=:newsId and bn.user.isActive=true")
     Integer countBookmarkNewsByNewsId(@Param("newsId") Long newsId);
 
-    @Query(value = "select * from bookmark_news_tb bn where DATE(bn.created_at)=:date and bn.user_id=:userId", nativeQuery = true)
-    List<BookmarkNews> findByCreatedAtAndUser(@Param("date")LocalDate date, @Param("userId") Long userId);
+//    @Query(value = "select * from bookmark_news_tb bn where DATE(bn.created_at)=:date and bn.user_id=:userId", nativeQuery = true)
+//    List<BookmarkNews> findByCreatedAtAndUser(@Param("date")LocalDate date, @Param("userId") Long userId);
 
 }

--- a/src/main/java/com/triplea/triplea/model/bookmark/BookmarkNewsRepository.java
+++ b/src/main/java/com/triplea/triplea/model/bookmark/BookmarkNewsRepository.java
@@ -18,7 +18,4 @@ public interface BookmarkNewsRepository extends JpaRepository<BookmarkNews, Long
     @Query("select count(bn) from BookmarkNews bn where bn.isDeleted=false and bn.newsId=:newsId and bn.user.isActive=true")
     Integer countBookmarkNewsByNewsId(@Param("newsId") Long newsId);
 
-//    @Query(value = "select * from bookmark_news_tb bn where DATE(bn.created_at)=:date and bn.user_id=:userId", nativeQuery = true)
-//    List<BookmarkNews> findByCreatedAtAndUser(@Param("date")LocalDate date, @Param("userId") Long userId);
-
 }

--- a/src/main/java/com/triplea/triplea/model/bookmark/BookmarkSymbol.java
+++ b/src/main/java/com/triplea/triplea/model/bookmark/BookmarkSymbol.java
@@ -5,13 +5,11 @@ import lombok.*;
 
 import javax.persistence.*;
 
-@Builder
 @Getter @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Table(name = "bookmark_symbol_tb")
 public class BookmarkSymbol {
-    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -23,6 +21,14 @@ public class BookmarkSymbol {
 
     @Column(nullable = false)
     private boolean isDeleted;
+
+    @Builder
+    public BookmarkSymbol(Long id, User user, Long symbolId, boolean isDeleted) {
+        this.id = id;
+        this.user = user;
+        this.symbolId = symbolId;
+        this.isDeleted = isDeleted;
+    }
 
     public void deleteBookmark(){
         this.isDeleted = true;

--- a/src/main/java/com/triplea/triplea/model/category/Category.java
+++ b/src/main/java/com/triplea/triplea/model/category/Category.java
@@ -10,7 +10,7 @@ import javax.persistence.*;
 @NoArgsConstructor
 @Table(name = "category_tb")
 public class Category {
-    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Column(nullable = false)
     private String category;

--- a/src/main/java/com/triplea/triplea/model/category/MainCategory.java
+++ b/src/main/java/com/triplea/triplea/model/category/MainCategory.java
@@ -13,7 +13,7 @@ import java.util.List;
 @NoArgsConstructor
 @Table(name = "main_category_tb")
 public class MainCategory {
-    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Column(nullable = false)
     private String mainCategoryEng;

--- a/src/main/java/com/triplea/triplea/model/history/History.java
+++ b/src/main/java/com/triplea/triplea/model/history/History.java
@@ -1,5 +1,6 @@
 package com.triplea.triplea.model.history;
 
+import com.querydsl.core.annotations.QueryEntity;
 import com.triplea.triplea.core.util.timestamp.CreatedTimestamped;
 import com.triplea.triplea.model.user.User;
 import lombok.*;
@@ -7,16 +8,30 @@ import lombok.*;
 import javax.persistence.*;
 
 @Entity
-@Getter @Builder
+@QueryEntity
+@Getter
 @NoArgsConstructor
-@AllArgsConstructor
 @Table(name = "history_tb")
 public class History extends CreatedTimestamped {
-    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
     @Column(nullable = false)
     private Long newsId;
+
+    @Builder
+    public History(Long id, User user, Long newsId) {
+        this.id = id;
+        this.user = user;
+        this.newsId = newsId;
+    }
+
+    @Builder
+    public History(User user, Long newsId) {
+        this.user = user;
+        this.newsId = newsId;
+    }
 }

--- a/src/main/java/com/triplea/triplea/model/history/HistoryQuerydslRepository.java
+++ b/src/main/java/com/triplea/triplea/model/history/HistoryQuerydslRepository.java
@@ -1,0 +1,14 @@
+package com.triplea.triplea.model.history;
+
+import com.triplea.triplea.model.user.User;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface HistoryQuerydslRepository {
+    List<LocalDate> findDateByCreatedAtAndUser(int year, int month, User user);
+
+    List<History> findByCreatedAtAndUser(LocalDate date, Long userId);
+
+    boolean existsByCreatedAtAndUserAndNewsId(LocalDate date, User user, Long newsId);
+}

--- a/src/main/java/com/triplea/triplea/model/history/HistoryQuerydslRepositoryImpl.java
+++ b/src/main/java/com/triplea/triplea/model/history/HistoryQuerydslRepositoryImpl.java
@@ -1,0 +1,71 @@
+package com.triplea.triplea.model.history;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.triplea.triplea.core.util.timestamp.Timestamped;
+import com.triplea.triplea.model.user.User;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Repository
+public class HistoryQuerydslRepositoryImpl implements HistoryQuerydslRepository {
+    private final JPAQueryFactory queryFactory;
+    private final QHistory history = QHistory.history;
+
+    public HistoryQuerydslRepositoryImpl(EntityManager entityManager) {
+        this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public List<LocalDate> findDateByCreatedAtAndUser(int year, int month, User user) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDate minDate = yearMonth.atDay(1);
+        LocalDate maxDate = yearMonth.atEndOfMonth();
+        ZonedDateTime startDateTime = ZonedDateTime.of(minDate, LocalTime.MIN, Timestamped.SEOUL_ZONE_ID);
+        ZonedDateTime endDateTime = ZonedDateTime.of(maxDate, LocalTime.MAX, Timestamped.SEOUL_ZONE_ID);
+
+        return queryFactory.select(history.createdAt)
+                .from(history)
+                .where(history.createdAt.between(startDateTime, endDateTime)
+                        .and(history.user.eq(user)))
+                .orderBy(history.createdAt.asc())
+                .fetch()
+                .stream()
+                .map(ZonedDateTime::toLocalDate)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<History> findByCreatedAtAndUser(LocalDate date, Long userId) {
+        ZonedDateTime startDateTime = ZonedDateTime.of(date, LocalTime.MIN, Timestamped.SEOUL_ZONE_ID);
+        ZonedDateTime endDateTime = ZonedDateTime.of(date, LocalTime.MAX, Timestamped.SEOUL_ZONE_ID);
+
+        return queryFactory.selectFrom(history)
+                .where(history.createdAt.between(startDateTime, endDateTime)
+                        .and(history.user.id.eq(userId)))
+                .fetch();
+    }
+
+    @Override
+    public boolean existsByCreatedAtAndUserAndNewsId(LocalDate date, User user, Long newsId) {
+        ZonedDateTime startDateTime = ZonedDateTime.of(date, LocalTime.MIN, Timestamped.SEOUL_ZONE_ID);
+        ZonedDateTime endDateTime = ZonedDateTime.of(date, LocalTime.MAX, Timestamped.SEOUL_ZONE_ID);
+
+        BooleanExpression condition = history.createdAt.between(startDateTime, endDateTime)
+                .and(history.user.eq(user))
+                .and(history.newsId.eq(newsId));
+
+        return queryFactory.selectOne()
+                .from(history)
+                .where(condition)
+                .fetchFirst() != null;
+    }
+}

--- a/src/main/java/com/triplea/triplea/model/history/HistoryRepository.java
+++ b/src/main/java/com/triplea/triplea/model/history/HistoryRepository.java
@@ -6,12 +6,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
-import java.time.ZonedDateTime;
+import java.util.Date;
 import java.util.List;
 
 public interface HistoryRepository extends JpaRepository<History, Long> {
-    @Query("select h.createdAt from History h where year (h.createdAt)=:year and month (h.createdAt)=:month and h.user=:user order by h.createdAt asc")
-    List<ZonedDateTime> findDateTimeByCreatedAtAndUser(@Param("year") int year, @Param("month") int month, @Param("user") User user);
+    @Query(value = "select DISTINCT DATE (h.created_at) from history_tb h where year (h.created_at)=:year and month (h.created_at)=:month and h.user_id=:user order by DATE(h.created_at) asc", nativeQuery = true)
+    List<Date> findDateTimeByCreatedAtAndUser(@Param("year") int year, @Param("month") int month, @Param("user") User user);
 
     @Query(value = "select * from history_tb h where DATE(h.created_at)=:date and h.user_id=:userId", nativeQuery = true)
     List<History> findByCreatedAtAndUser(@Param("date") LocalDate date, @Param("userId") Long userId);

--- a/src/main/java/com/triplea/triplea/model/history/HistoryRepository.java
+++ b/src/main/java/com/triplea/triplea/model/history/HistoryRepository.java
@@ -1,25 +1,6 @@
 package com.triplea.triplea.model.history;
 
-import com.triplea.triplea.model.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.time.LocalDate;
-import java.util.Date;
-import java.util.List;
 
 public interface HistoryRepository extends JpaRepository<History, Long> {
-    @Query(value = "select DISTINCT DATE (h.created_at) from history_tb h where year (h.created_at)=:year and month (h.created_at)=:month and h.user_id=:user order by DATE(h.created_at) asc", nativeQuery = true)
-    List<Date> findDateTimeByCreatedAtAndUser(@Param("year") int year, @Param("month") int month, @Param("user") User user);
-
-    @Query(value = "select * from history_tb h where DATE(h.created_at)=:date and h.user_id=:userId", nativeQuery = true)
-    List<History> findByCreatedAtAndUser(@Param("date") LocalDate date, @Param("userId") Long userId);
-
-    @Query(value = "select count(*) AS result from history_tb h where DATE(h.created_at)=:date and h.user_id=:userId and h.news_id=:newsId", nativeQuery = true)
-    Long countByCreatedAtAndUserAndNewsId(@Param("date") LocalDate date, @Param("userId") Long userId, @Param("newsId") Long newsId);
-
-    default boolean existsByCreatedAtAndUserAndNewsId(LocalDate date, User user, Long newsId) {
-        return countByCreatedAtAndUserAndNewsId(date, user.getId(), newsId) > 0;
-    }
 }

--- a/src/main/java/com/triplea/triplea/model/user/User.java
+++ b/src/main/java/com/triplea/triplea/model/user/User.java
@@ -13,7 +13,7 @@ import javax.persistence.*;
 @Table(name = "user_tb")
 public class User extends Timestamped {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)
@@ -65,13 +65,30 @@ public class User extends Timestamped {
         this.profile = profile;
     }
 
+
+    @Builder
+    public User(String email, String password, String fullName, boolean newsLetter, boolean emailVerified, String userAgent, String clientIP, String profile) {
+        this.email = email;
+        this.password = password;
+        this.fullName = fullName;
+        this.newsLetter = newsLetter;
+        this.isEmailVerified = emailVerified;
+        this.isActive = true;
+        this.membership = Membership.BASIC;
+        this.userAgent = userAgent;
+        this.clientIP = clientIP;
+        this.profile = profile;
+    }
+
     public void updatePassword(String password) {
         this.password = password;
     }
-    public void updateFullName(String fullName){
+
+    public void updateFullName(String fullName) {
         this.fullName = fullName;
     }
-    public void updateNewsLetter(boolean newsLetter){
+
+    public void updateNewsLetter(boolean newsLetter) {
         this.newsLetter = newsLetter;
     }
 

--- a/src/main/java/com/triplea/triplea/service/NewsService.java
+++ b/src/main/java/com/triplea/triplea/service/NewsService.java
@@ -48,10 +48,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -387,11 +384,10 @@ public class NewsService {
 
     // 히스토리 조회
     public List<NewsResponse.HistoryOut> getHistory(int year, int month, User user) {
-        List<ZonedDateTime> historyDateTimes = historyRepository.findDateTimeByCreatedAtAndUser(year, month, user);
+        List<Date> historyDateTimes = historyRepository.findDateTimeByCreatedAtAndUser(year, month, user);
 
-        return historyDateTimes.stream().map(dateTime -> {
-            LocalDate date = dateTime.toLocalDate();
-
+        return historyDateTimes.stream().map(historyDate -> {
+            LocalDate date = Instant.ofEpochMilli(historyDate.getTime()).atZone(Timestamped.SEOUL_ZONE_ID).toLocalDate();
             List<NewsResponse.HistoryOut.Bookmark.News> bookmarkNews = bookmarkNewsRepository.findByCreatedAtAndUser(date, user.getId())
                     .stream()
                     .map(bookmark -> NewsResponse.HistoryOut.Bookmark.News.builder()

--- a/src/test/java/com/triplea/triplea/service/NewsServiceTest.java
+++ b/src/test/java/com/triplea/triplea/service/NewsServiceTest.java
@@ -10,7 +10,6 @@ import com.triplea.triplea.core.util.provide.MoyaNewsProvider;
 import com.triplea.triplea.core.util.provide.TiingoStockProvider;
 import com.triplea.triplea.core.util.provide.symbol.MoyaSymbolProvider;
 import com.triplea.triplea.core.util.provide.symbol.TiingoSymbolProvider;
-import com.triplea.triplea.core.util.timestamp.Timestamped;
 import com.triplea.triplea.core.util.translate.Papago;
 import com.triplea.triplea.core.util.translate.WiseSTGlobal;
 import com.triplea.triplea.dto.news.ApiResponse;
@@ -42,11 +41,7 @@ import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.time.LocalDate;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -707,8 +702,7 @@ class NewsServiceTest extends DummyEntity {
             int year = 2023;
             int month = 6;
             //when
-            ZonedDateTime zonedDateTime = ZonedDateTime.now(Timestamped.SEOUL_ZONE_ID);
-            List<ZonedDateTime> dateTimes = List.of(zonedDateTime);
+            List<Date> dateTimes = List.of(new Date());
             History history = History.builder()
                     .id(1L)
                     .user(user)

--- a/src/test/java/com/triplea/triplea/service/NewsServiceTest.java
+++ b/src/test/java/com/triplea/triplea/service/NewsServiceTest.java
@@ -18,6 +18,7 @@ import com.triplea.triplea.dto.news.NewsResponse;
 import com.triplea.triplea.dto.stock.StockRequest;
 import com.triplea.triplea.dto.stock.StockResponse;
 import com.triplea.triplea.dto.symbol.SymbolRequest;
+import com.triplea.triplea.model.bookmark.BookmarkNewsQuerydslRepository;
 import com.triplea.triplea.model.bookmark.BookmarkNewsRepository;
 import com.triplea.triplea.model.category.Category;
 import com.triplea.triplea.model.category.CategoryRepository;
@@ -26,6 +27,7 @@ import com.triplea.triplea.model.category.MainCategoryRepository;
 import com.triplea.triplea.model.customer.Customer;
 import com.triplea.triplea.model.customer.CustomerRepository;
 import com.triplea.triplea.model.history.History;
+import com.triplea.triplea.model.history.HistoryQuerydslRepository;
 import com.triplea.triplea.model.history.HistoryRepository;
 import com.triplea.triplea.model.user.User;
 import com.triplea.triplea.model.user.UserRepository;
@@ -41,7 +43,10 @@ import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.time.LocalDate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -54,6 +59,8 @@ class NewsServiceTest extends DummyEntity {
     @Mock
     BookmarkNewsRepository bookmarkNewsRepository;
     @Mock
+    BookmarkNewsQuerydslRepository bookmarkNewsQuerydslRepository;
+    @Mock
     MainCategoryRepository mainCategoryRepository;
     @Mock
     CategoryRepository categoryRepository;
@@ -63,6 +70,8 @@ class NewsServiceTest extends DummyEntity {
     CustomerRepository customerRepository;
     @Mock
     HistoryRepository historyRepository;
+    @Mock
+    HistoryQuerydslRepository historyQuerydslRepository;
     @Mock
     MoyaNewsProvider newsProvider;
     @Mock
@@ -494,7 +503,7 @@ class NewsServiceTest extends DummyEntity {
                         .content("내용")
                         .build();
                 when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
-                when(historyRepository.existsByCreatedAtAndUserAndNewsId(any(), any(User.class), anyLong())).thenReturn(true);
+                when(historyQuerydslRepository.existsByCreatedAtAndUserAndNewsId(any(), any(User.class), anyLong())).thenReturn(true);
                 when(newsProvider.getNewsById(anyLong())).thenReturn(newsResponse);
                 when(newsProvider.getNewsDetails(any(Response.class))).thenReturn(data);
                 when(mainCategoryRepository.findMainCategoryBySubCategory(anyString())).thenReturn(Optional.of(mainCategory));
@@ -508,7 +517,7 @@ class NewsServiceTest extends DummyEntity {
                 NewsResponse.Details result = newsService.getNewsDetails(id, user);
                 //then
                 verify(userRepository, times(1)).findById(anyLong());
-                verify(historyRepository, times(1)).existsByCreatedAtAndUserAndNewsId(any(), any(User.class), anyLong());
+                verify(historyQuerydslRepository, times(1)).existsByCreatedAtAndUserAndNewsId(any(), any(User.class), anyLong());
                 verify(newsProvider, times(1)).getNewsById(anyLong());
                 verify(newsProvider, times(1)).getNewsDetails(any());
                 verify(mainCategoryRepository, times(1)).findMainCategoryBySubCategory(anyString());
@@ -581,7 +590,7 @@ class NewsServiceTest extends DummyEntity {
                 String title = "제목";
                 List<Long> newsId = List.of(2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L);
                 when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
-                when(historyRepository.existsByCreatedAtAndUserAndNewsId(any(), any(User.class), anyLong())).thenReturn(true);
+                when(historyQuerydslRepository.existsByCreatedAtAndUserAndNewsId(any(), any(User.class), anyLong())).thenReturn(true);
                 when(newsProvider.getNewsById(anyLong())).thenReturn(newsResponse);
                 when(newsProvider.getNewsDetails(any(Response.class))).thenReturn(data);
                 when(mainCategoryRepository.findMainCategoryBySubCategory(anyString())).thenReturn(Optional.of(mainCategory));
@@ -595,7 +604,7 @@ class NewsServiceTest extends DummyEntity {
                 NewsResponse.Details result = newsService.getNewsDetails(id, user);
                 //then
                 verify(userRepository, times(1)).findById(anyLong());
-                verify(historyRepository, times(1)).existsByCreatedAtAndUserAndNewsId(any(), any(User.class), anyLong());
+                verify(historyQuerydslRepository, times(1)).existsByCreatedAtAndUserAndNewsId(any(), any(User.class), anyLong());
                 verify(newsProvider, times(1)).getNewsById(anyLong());
                 verify(newsProvider, times(1)).getNewsDetails(any());
                 verify(mainCategoryRepository, times(1)).findMainCategoryBySubCategory(anyString());
@@ -702,21 +711,21 @@ class NewsServiceTest extends DummyEntity {
             int year = 2023;
             int month = 6;
             //when
-            List<Date> dateTimes = List.of(new Date());
+            List<LocalDate> dates = List.of(LocalDate.now());
             History history = History.builder()
                     .id(1L)
                     .user(user)
                     .newsId(newsId)
                     .build();
             List<History> histories = List.of(history);
-            when(historyRepository.findDateTimeByCreatedAtAndUser(anyInt(), anyInt(), any(User.class))).thenReturn(dateTimes);
-            when(bookmarkNewsRepository.findByCreatedAtAndUser(any(), anyLong())).thenReturn(Collections.emptyList());
-            when(historyRepository.findByCreatedAtAndUser(any(), anyLong())).thenReturn(histories);
+            when(historyQuerydslRepository.findDateByCreatedAtAndUser(anyInt(), anyInt(), any(User.class))).thenReturn(dates);
+            when(bookmarkNewsQuerydslRepository.findByCreatedAtAndUser(any(), anyLong())).thenReturn(Collections.emptyList());
+            when(historyQuerydslRepository.findByCreatedAtAndUser(any(), anyLong())).thenReturn(histories);
             List<NewsResponse.HistoryOut> result = newsService.getHistory(year, month, user);
             //then
-            verify(historyRepository, times(1)).findDateTimeByCreatedAtAndUser(anyInt(), anyInt(), any(User.class));
-            verify(bookmarkNewsRepository, times(1)).findByCreatedAtAndUser(any(), anyLong());
-            verify(historyRepository, times(1)).findByCreatedAtAndUser(any(), anyLong());
+            verify(historyQuerydslRepository, times(1)).findDateByCreatedAtAndUser(anyInt(), anyInt(), any(User.class));
+            verify(bookmarkNewsQuerydslRepository, times(1)).findByCreatedAtAndUser(any(), anyLong());
+            verify(historyQuerydslRepository, times(1)).findByCreatedAtAndUser(any(), anyLong());
             Assertions.assertEquals(1, result.size());
             Assertions.assertEquals(0, result.get(0).getBookmark().getCount());
             Assertions.assertTrue(result.get(0).getBookmark().getNews().isEmpty());


### PR DESCRIPTION
## Motivation

- 리팩토링
- close #104 

## Proposed Changes

- id전략 IDENTITY로 변경
- History 및 BookmarkNews JPQL에서 queryDSL로 변경(일부)

## To reviewers

- 주의할 점
- 안내사항